### PR TITLE
Fix install/uninstall script

### DIFF
--- a/setup/install.wlua
+++ b/setup/install.wlua
@@ -24,7 +24,7 @@ elseif ui.dpi >= 1.75 then
     factor = 2
 end
 
-local win = ui.Window("", "raw", 400, 155*factor)
+local win = ui.Window("", "raw", 400, math.floor(155*factor))
 win.font = "Segoe UI"
 win.installation = false
 

--- a/setup/uninstall.wlua
+++ b/setup/uninstall.wlua
@@ -32,7 +32,7 @@ elseif ui.dpi >= 1.75 then
     factor = 2
 end
 
-local win = ui.Window("", "raw", 400, 155*factor)
+local win = ui.Window("", "raw", 400, math.floor(155*factor))
 win.bgcolor = ui.theme == "light" and 0xFFFFFF or 0
 win.font = "Segoe UI"
 win.installation = false


### PR DESCRIPTION
When I install LuaRT 1.9, it shows me:
```
Runtime error
install.wlua:27: bad argument #5 in method 'Window.constructor' (number has no integer representation)
```

My `ui.dpi` is 1.5, the window's height is 155*1.5=232.5 (not an integer).
https://github.com/samyeyo/LuaRT/blob/18eb0b3c1ed9579d9318392182896d0aef075312/setup/install.wlua#L18-L27

So I changed 155 to 156, ensuring that all three conditions are integers, or would it be better to use math.floor() instead.
